### PR TITLE
[Main] 수리접수 ID(Long) → 접수번호(String)으로 변경

### DIFF
--- a/src/main/java/com/gearfirst/backend/api/order/controller/PurchaseOrderController.java
+++ b/src/main/java/com/gearfirst/backend/api/order/controller/PurchaseOrderController.java
@@ -91,9 +91,9 @@ public class PurchaseOrderController {
     }
 
     @Operation(summary = "대리점에서 수리 완료 시 발주한 부품 목록 조회", description = "대리점에서 발주 상태를 '수리에 사용됨'으로 변경하고, 해당 발주의 부품 목록을 반환합니다.")
-    @PostMapping("/complete/parts/{receiptId}/{vehicleNumber}")
-    public ResponseEntity<ApiResponse<List<RepairPartResponse>>> completeRepairParts(@PathVariable Long receiptId, @PathVariable String vehicleNumber, @RequestParam Long branchId, @RequestParam Long engineerId ){
-        List<RepairPartResponse> response = purchaseOrderService.completeRepairAndGetParts(receiptId,vehicleNumber,branchId,engineerId);
+    @PostMapping("/complete/parts/{receiptNum}/{vehicleNumber}")
+    public ResponseEntity<ApiResponse<List<RepairPartResponse>>> completeRepairParts(@PathVariable String receiptNum, @PathVariable String vehicleNumber, @RequestParam Long branchId, @RequestParam Long engineerId ){
+        List<RepairPartResponse> response = purchaseOrderService.completeRepairAndGetParts(receiptNum,vehicleNumber,branchId,engineerId);
         return ApiResponse.success(SuccessStatus.SEARCH_PARTS_SUCCESS,response);
     }
 

--- a/src/main/java/com/gearfirst/backend/api/order/dto/request/PurchaseOrderRequest.java
+++ b/src/main/java/com/gearfirst/backend/api/order/dto/request/PurchaseOrderRequest.java
@@ -12,6 +12,6 @@ public class PurchaseOrderRequest {
     private String vehicleModel;
     private Long engineerId;
     private Long branchId;
-    private Long receiptId;
+    private String receiptNum;
     private List<OrderItemRequest> items;
 }

--- a/src/main/java/com/gearfirst/backend/api/order/entity/PurchaseOrder.java
+++ b/src/main/java/com/gearfirst/backend/api/order/entity/PurchaseOrder.java
@@ -37,17 +37,17 @@ public class PurchaseOrder {
     @Column(name="order_number", nullable = false)
     private String orderNumber;         //발주 번호
 
-    @Column(name="vehicle_number", nullable = false)
+    @Column(name="vehicle_number")
     private String vehicleNumber;        //차량 번호
 
-    @Column(name="vehicle_model", nullable = false)
+    @Column(name="vehicle_model")
     private String vehicleModel;        //차량 모델
 
     @Column(name="engineer_id", nullable = false)
     private Long engineerId;            //엔지니어 id
 
-    @Column(name="receipt_id", nullable = false)
-    private Long receiptId;              //수리 이력 id
+    @Column(name="receipt_num")
+    private String receiptNum;              //수리 이력 Num
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
@@ -61,14 +61,14 @@ public class PurchaseOrder {
 
 
     @Builder
-    public PurchaseOrder(String vehicleNumber, String vehicleModel, Long engineerId, Long branchId, Long receiptId) {
+    public PurchaseOrder(String vehicleNumber, String vehicleModel, Long engineerId, Long branchId, String receiptNum) {
         this.requestDate = LocalDateTime.now();
         this.orderNumber = generateOrderNumber(this.requestDate);
         this.vehicleNumber = vehicleNumber;
         this.vehicleModel = vehicleModel;
         this.engineerId = engineerId;
         this.branchId = branchId;
-        this.receiptId = receiptId;
+        this.receiptNum = receiptNum;
         this.status = OrderStatus.PENDING; //기본 상태 승인 대기
         this.totalPrice = 0;
     }

--- a/src/main/java/com/gearfirst/backend/api/order/repository/PurchaseOrderRepository.java
+++ b/src/main/java/com/gearfirst/backend/api/order/repository/PurchaseOrderRepository.java
@@ -23,7 +23,7 @@ public interface PurchaseOrderRepository extends JpaRepository<PurchaseOrder,Lon
     List<PurchaseOrder> findByStatusOrderByRequestDateDesc(OrderStatus status);
 
     //차량 번호와 상태로 발주 내역 조회
-    Optional<PurchaseOrder> findByVehicleNumberAndBranchIdAndEngineerIdAndStatusAndReceiptId(String vehicleNumber, Long branchId, Long engineerId, OrderStatus orderStatus,Long receiptId);
+    Optional<PurchaseOrder> findByVehicleNumberAndBranchIdAndEngineerIdAndStatusAndReceiptNum(String vehicleNumber, Long branchId, Long engineerId, OrderStatus orderStatus,String receiptNum);
 
     //대리점 발주 내역 상세 조회
     Optional<PurchaseOrder> findByIdAndBranchIdAndEngineerId(Long id, Long branchId, Long engineerId);

--- a/src/main/java/com/gearfirst/backend/api/order/service/PurchaseOrderService.java
+++ b/src/main/java/com/gearfirst/backend/api/order/service/PurchaseOrderService.java
@@ -25,7 +25,7 @@ public interface PurchaseOrderService {
      */
     //List<PurchaseOrderResponse> getHeadPurchaseOrdersByStatus(String status);
     //수리 완료 처리 및 발주 부품 조회
-    List<RepairPartResponse> completeRepairAndGetParts(Long receiptId, String vehicleNumber, Long branchId, Long engineerId);
+    List<RepairPartResponse> completeRepairAndGetParts(String receiptNum, String vehicleNumber, Long branchId, Long engineerId);
     //발주 상세 조회
     PurchaseOrderResponse getPurchaseOrderDetail(Long orderId,Long branchId, Long engineerId);
     //대리점 발주 취소

--- a/src/test/java/com/gearfirst/backend/api/order/service/PurchaseOrderServiceImplTest.java
+++ b/src/test/java/com/gearfirst/backend/api/order/service/PurchaseOrderServiceImplTest.java
@@ -39,7 +39,7 @@ class PurchaseOrderServiceImplTest {
     private final RepairClient repairClient = mock(RepairClient.class);
 
     private final PurchaseOrderService service = new PurchaseOrderServiceImpl(
-           purchaseOrderRepository, orderItemRepository, inventoryClient, repairClient
+           purchaseOrderRepository, orderItemRepository, inventoryClient
     );
 
 //    @Test


### PR DESCRIPTION
## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
발주 요청 시:
- 수리접수 ID(Long) → 접수번호(String)으로 변경
- 필수 입력값: 대리점 ID, 엔지니어 ID, item 리스트만 필수로 유지
- 수리접수 없이도 부품만 요청할 수 있도록 로직 수정

수리 접수 완료 처리 시:
- 수리접수 ID → 접수번호(String)으로 변경




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링**
  * 영수증 식별자 형식이 숫자에서 문자열로 변경되었습니다.
  * 부품 완료 API 엔드포인트 경로가 업데이트되었습니다.

* **버그 수정**
  * 차량 정보 필드를 선택적으로 변경하여 데이터 유효성 검사 개선을 완료했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->